### PR TITLE
feat(bonus): Add Privilege De-escalation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ COPY . .
 RUN go build -o /usr/local/bin/taskmasterd cmd/server/main.go
 RUN go build -o /usr/local/bin/taskmasterctl cmd/client/main.go
 
-# CMD [ "taskmasterd" ]
-CMD ["tail", "-f"]
+RUN useradd "taskmaster"
+
+CMD [ "taskmasterd" ]

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -38,6 +38,17 @@ func (m *JobManager) Init() error {
 		return err
 	}
 
+	if conf.User != "" {
+		fmt.Printf("[NOTICE] De-escalating privilege to user %v\n", conf.User)
+
+		if err := utils.DeEscalatePrivilege(conf.User); err != nil {
+			utils.Errorf(err.Error())
+			os.Exit(1)
+		}
+
+		fmt.Println("[NOTICE] De-escalation successful")
+	}
+
 	var jobs []*job.Job
 	for name, prog := range conf.Programs {
 		jobs = append(jobs, job.NewJob(name, prog))

--- a/internal/parser/config/config.go
+++ b/internal/parser/config/config.go
@@ -15,11 +15,12 @@ type Program struct {
 	Directory     string   `toml:"directory"`
 	StdoutLogFile string   `toml:"stdout_logfile"`
 	StderrLogFile string   `toml:"stderr_logfile"`
-	Umask string `toml:"umask" validate:"default=0022"`
+	Umask         string   `toml:"umask" validate:"default=0022"`
 }
 
 type Config struct {
 	Programs map[string]*Program `toml:"program"`
+	User     string              `toml:"user"`
 }
 
 func ParseCommand(cmd string) []string {

--- a/internal/utils/setup.go
+++ b/internal/utils/setup.go
@@ -1,6 +1,10 @@
 package utils
 
 import (
+	"strconv"
+	"syscall"
+	"os/user"
+
 	"github.com/Archer-01/taskmaster/internal/parser/config"
 	"github.com/BurntSushi/toml"
 )
@@ -29,4 +33,24 @@ func ParseSetupFile() (Setup, error) {
 	}
 
 	return setup, nil
+}
+
+func DeEscalatePrivilege(username string) error {
+	u, err := user.Lookup(username)
+
+	if err != nil {
+		return err
+	}
+
+	newUid, err := strconv.Atoi(u.Uid)
+
+	if err != nil {
+		return err
+	}
+
+	if err := syscall.Setuid(newUid); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/taskmaster.toml
+++ b/taskmaster.toml
@@ -1,3 +1,5 @@
+user = "taskmaster"
+
 [program.one]
 command = "ping localhost"
 


### PR DESCRIPTION
- Switch to a certain user before doing any meaningful processing
- The user can only be switched if taskmasterd is started as root
- If taskmasterd can't switch to the specified user, it writes an error message to stderr and then exits immediately

https://supervisord.org/configuration.html#supervisord-section-settings